### PR TITLE
feat: support deny action in bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ metadata:
   name: my-policy-binding
 spec:
   policyName: my-policy
-  validationActions: [Warn]
+  validationActions: [Deny]
   matchResources:
     namespaceSelector:
       matchLabels:
@@ -439,7 +439,7 @@ metadata:
   name: my-policy-binding
 spec:
   policyName: my-policy
-  validationActions: [Warn]
+  validationActions: [Deny]
   matchResources:
     namespaceSelector:
       matchExpressions:
@@ -450,7 +450,7 @@ spec:
 
 The `policyName` field refers to `MonoklePolicy` resource name, while `matchResources` is optional and can be used to narrow binding scope to specific namespace. If follows the same convention as in other Kubernetes kinds, supporting `namespaceSelector` with `matchLabels` and `matchExpressions`.
 
-The `validationActions` support only `Warn` at this stage, which means "send a warning for every policy violation detected". In the upcoming versions it will be expanded to more actions like - `Ignore`, `Report` and `Deny` (see [#10](https://github.com/kubeshop/monokle-admission-controller/issues/10)).
+The `validationActions` supports `Warn` and `Deny` actions at this stage. `Warn` means "send a warning for every policy violation detected" and `Deny` will block resource creation/update when there are any violations. In the upcoming versions it will be expanded to more actions like - `Ignore` and `Report` (see [#10](https://github.com/kubeshop/monokle-admission-controller/issues/10)).
 
 ## Customizing Helm deployment
 

--- a/examples/policy-binding-sample-6.yaml
+++ b/examples/policy-binding-sample-6.yaml
@@ -1,0 +1,14 @@
+apiVersion: monokle.io/v1alpha1
+kind: MonoklePolicyBinding
+metadata:
+  name: policy-binding-sample-5
+spec:
+  policyName: "policy-sample-1"
+  validationActions: [Deny]
+  matchResources:
+    namespaceSelector:
+      matchExpressions:
+        - key: name
+          operator: In
+          values:
+            - default

--- a/helm/templates/monokle-policy-binding-crd.yaml
+++ b/helm/templates/monokle-policy-binding-crd.yaml
@@ -26,7 +26,7 @@ spec:
                   type: array
                   items:
                     type: string
-                    enum: [Warn]
+                    enum: [Warn, Deny]
                 matchResources:
                   type: object
                   properties:


### PR DESCRIPTION
This PR adds support for `Deny` action in policy bindings. It partially solves #10. It is based on and targets `f1ames/feat/cloud-integration` branch and should be merged after it.

Now, for `Warn` action, the list of violations is send as warnings. For `Deny` it is same but send as regular output, additionally resource is blocked and so it is interpreted as error by client (e.g. `kubectl`).

As stated in [VAP docs](https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/#validation-actions) (which we try to align) with:
> `Deny` and `Warn` may not be used together since this combination needlessly duplicates the validation failure both in the API response body and the HTTP warning headers.

## Changes

- As above.

## Fixes

- None.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [x] updated the docs
- [x] added a test
