### PR TITLE
Adjust to Cloud API

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,9 +45,10 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Build image and push to Docker Hub
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: ./admission-controller/${{ matrix.from }}/
+          platforms: linux/amd64,linux/arm64,linux/arm/v8,linux/arm/v7
           file: ./admission-controller/${{ matrix.from }}/Dockerfile
           tags: |
             kubeshop/monokle-admission-controller-${{ matrix.from }}:latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ on:
       - examples/**
       - helm/**
       - scripts/**
-      - test/**
+      - tests/**
   push:
     branches:
       - main
@@ -18,7 +18,7 @@ on:
       - examples/**
       - helm/**
       - scripts/**
-      - test/**
+      - tests/**
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -71,7 +71,7 @@ jobs:
         run: minikube start --extra-config=apiserver.enable-admission-plugins=ValidatingAdmissionWebhook
 
       - name: Deploy Admission Controller
-        run: ./scripts/deploy-${{ matrix.type }}.sh host.minikube.internal:5000
+        run: ./scripts/deploy-${{ matrix.type }}.sh host.minikube.internal:5000 SAMPLE_TOKEN
 
       - name: Preview namespace state
         run: kubectl -n monokle-admission-controller get all,CustomResourceDefinition,ValidatingWebhookConfiguration,secrets

--- a/admission-controller/synchronizer/package-lock.json
+++ b/admission-controller/synchronizer/package-lock.json
@@ -12,7 +12,8 @@
         "@kubernetes/client-node": "^0.19.0",
         "@monokle/synchronizer": "^0.10.2",
         "lodash": "^4.17.21",
-        "pino": "^8.16.1"
+        "pino": "^8.16.1",
+        "yaml": "^2.3.4"
       },
       "devDependencies": {
         "@types/lodash": "^4.14.200",
@@ -1196,9 +1197,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yaml": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.3.tgz",
-      "integrity": "sha512-zw0VAJxgeZ6+++/su5AFoqBbZbrEakwu+X0M5HmcwUiBL7AzcuPKjj5we4xfQLp78LkEMpD0cOnUhmgOVy3KdQ==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.4.tgz",
+      "integrity": "sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==",
       "engines": {
         "node": ">= 14"
       }

--- a/admission-controller/synchronizer/package.json
+++ b/admission-controller/synchronizer/package.json
@@ -13,7 +13,8 @@
     "@kubernetes/client-node": "^0.19.0",
     "@monokle/synchronizer": "^0.10.2",
     "lodash": "^4.17.21",
-    "pino": "^8.16.1"
+    "pino": "^8.16.1",
+    "yaml": "^2.3.4"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.200",

--- a/admission-controller/synchronizer/src/utils/queries.ts
+++ b/admission-controller/synchronizer/src/utils/queries.ts
@@ -1,9 +1,10 @@
-import {ValidationConfig} from "@monokle/types";
-
 export type ClusterQueryResponseBindingPolicy = {
   id: string
-  content: ValidationConfig
-  projectId: string
+  content: string
+  project: {
+    id: string
+    name: string
+  }
 };
 
 export type ClusterQueryResponseBinding = {
@@ -13,54 +14,52 @@ export type ClusterQueryResponseBinding = {
   policy: ClusterQueryResponseBindingPolicy
 };
 
+export type ClusterQueryResponseNamespace = {
+  id: string
+  name: string
+};
+
 export type ClusterQueryResponse = {
   getCluster: {
-    cluster: {
-      id: string
-      name: string
-      namespaceSync: boolean
+    id: string
+    name: string
+    namespaceSync: boolean
 
-      namespaces: {
-        id: string
-        name: string
-      }[]
+    namespaces: ClusterQueryResponseNamespace[]
 
-      bindings: ClusterQueryResponseBinding[]
-    }
+    bindings: ClusterQueryResponseBinding[]
   }
 };
 
 export type ClusterDiscoveryMutationResponse = {
   clusterDiscovery: {
-    version: string
-    namespaces?: string[]
+    id: string
+    namespaces: string[]
   }
 };
 
 export const getClusterQuery = `
-  query getCluster {
-    getCluster {
-      cluster {
+  query getCluster($input: ClusterGetInput!) {
+    getCluster(input: $input) {
+      id
+      name
+      namespaceSync
+
+      namespaces {
         id
         name
-        namespaceSync
+      }
 
-        namespaces {
+      bindings {
+        id
+        mode
+        namespaces
+        policy {
           id
-          name
-        }
-
-        bindings {
-          id
-          mode
-          namespaces {
+          content
+          project {
             id
             name
-          }
-          policy {
-            id
-            content
-            projectId
           }
         }
       }
@@ -69,14 +68,14 @@ export const getClusterQuery = `
 `;
 
 export const clusterDiscoveryMutation = `
-  mutation clusterDiscovery($version: String!, $namespaces: String[]) {
-    clusterDiscovery(
+  mutation discoverCluster($version: String!, $namespaces: [String!]!) {
+    discoverCluster(
       input: {
         version: $version,
         namespaces: $namespaces
       }
     ) {
-      version
+      id
       namespaces
     }
   }

--- a/helm/templates/service-account-synchronizer.yaml
+++ b/helm/templates/service-account-synchronizer.yaml
@@ -17,7 +17,7 @@ metadata:
 rules:
 - apiGroups: ["monokle.io"]
   resources: ["policies", "policybindings"]
-  verbs: ["create", "patch", "delete"]
+  verbs: ["list", "create", "patch", "update", "delete"]
 - apiGroups: [""]
   resources: ["namespaces"]
   verbs: ["list", "watch", "get"]

--- a/scripts/deploy-cloud.sh
+++ b/scripts/deploy-cloud.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 
 basedir="$(dirname "$0")"
 cloudApiUrl="$1"
+automationToken="$2"
 
 # Generate install.yaml
 #
@@ -18,7 +19,7 @@ helm template "${basedir}/../helm" \
 --set image.synchronizer.overridePath=admission-synchronizer \
 --set logLevel=debug \
 --set cloudApiUrl=$cloudApiUrl \
---set automationToken=SAMPLE_TOKEN > "${basedir}/install.yaml"
+--set automationToken=$automationToken > "${basedir}/install.yaml"
 
 # Run deployment through skaffold with locally build images
 skaffold run -f "${basedir}/skaffold.yaml"

--- a/scripts/dev-cloud.sh
+++ b/scripts/dev-cloud.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 
 basedir="$(dirname "$0")"
 cloudApiUrl="$1"
+automationToken="$2"
 
 # Generate install.yaml
 #
@@ -18,7 +19,7 @@ helm template "${basedir}/../helm" \
 --set image.synchronizer.overridePath=admission-synchronizer \
 --set logLevel=debug \
 --set cloudApiUrl=$cloudApiUrl \
---set automationToken=SAMPLE_TOKEN > "${basedir}/install.yaml"
+--set automationToken=$automationToken > "${basedir}/install.yaml"
 
 # Run development through skaffold with locally build images
 skaffold dev -f "${basedir}/skaffold.yaml"

--- a/tests/src/cloud.e2e.spec.ts
+++ b/tests/src/cloud.e2e.spec.ts
@@ -1,7 +1,7 @@
 import { join, resolve } from 'path';
 import { afterEach, assert, beforeAll, describe, it } from 'vitest'
 import shell from 'shelljs';
-import { parse } from 'yaml'
+import { parse } from 'yaml';
 import { startMockServer } from './utils/server';
 import { EXPECTED_CRDS } from './utils/expected-crds';
 

--- a/tests/src/cloud.e2e.spec.ts
+++ b/tests/src/cloud.e2e.spec.ts
@@ -56,10 +56,10 @@ describe(`Cloud (dir: ${mainDir})`, () => {
     mockServer = await startMockServer('empty');
 
     const requestsData = await waitForRequests(mockServer, 2);
-    const requestData = requestsData.find(requestData => requestData.body.query.includes('clusterDiscovery'));
+    const requestData = requestsData.find(requestData => requestData.body.query.includes('discoverCluster'));
 
     assert.match(requestData.token, /ApiKey SAMPLE_TOKEN/);
-    assert.match(requestData.body.query, /mutation clusterDiscovery/);
+    assert.match(requestData.body.query, /mutation discoverCluster/);
   }, 25 * 1000);
 
   it('propagates fetched cluster data as CRDs', async () => {

--- a/tests/src/utils/expected-crds.ts
+++ b/tests/src/utils/expected-crds.ts
@@ -60,17 +60,9 @@ export const EXPECTED_CRDS: Record<string, any> = {
     },
     spec: {
       plugins: {
-        'yaml-syntax': true,
-        'open-policy-agent': true,
-        'resource-links': true,
-      },
-      rules: {
-        'yaml-syntax/no-bad-alias': "warn",
-        'yaml-syntax/no-bad-directive': false,
-        'open-policy-agent/no-last-image': "err",
-        'open-policy-agent/cpu-limit': "err",
-        'open-policy-agent/memory-limit': "err",
-        'open-policy-agent/memory-request': "err",
+        'pod-security-standards': true,
+        'yaml-syntax': false,
+        'resource-links': false,
       }
     }
   }

--- a/tests/src/utils/response-mocks.ts
+++ b/tests/src/utils/response-mocks.ts
@@ -2,88 +2,88 @@ export const RESPONSE_MOCK: Record<string, any> = {
   empty: {
     data: {
       getCluster: {
-        cluster: {
-          id: "cluster-1",
-          name: "Cluster 1",
-          namespaceSync: false,
-          namespaces: [],
-          bindings: []
-        }
+        id: "cluster-1",
+        name: "Cluster 1",
+        namespaceSync: false,
+        namespaces: [],
+        bindings: []
       }
     }
   },
   emptySync: {
     data: {
       getCluster: {
-        cluster: {
-          id: "cluster-1",
-          name: "Cluster 1",
-          namespaceSync: false,
-          namespaces: [],
-          bindings: []
-        }
+        id: "cluster-1",
+        name: "Cluster 1",
+        namespaceSync: false,
+        namespaces: [],
+        bindings: []
       }
     }
   },
   dataAllow: {
     data: {
       getCluster: {
-        cluster: {
-          id: "cluster-1",
-          name: "Cluster 1",
-          namespaceSync: true,
-          namespaces: [
-            {
-              id: "ns-0",
-              name: "my-namespace-0"
-            },
-            {
-              id: "ns-1",
-              name: "my-namespace-1"
+        id: "cluster-1",
+        name: "Cluster 1",
+        namespaceSync: true,
+        namespaces: [
+          {
+            id: "ns-0",
+            name: "my-namespace-0"
+          },
+          {
+            id: "ns-1",
+            name: "my-namespace-1"
+          }
+        ],
+        bindings: [
+          {
+            id: "cluster-1-binding-1",
+            mode: "ALLOW_LIST",
+            namespaces: ["ns-0","ns-1"],
+            policy: {
+              id: "cluster-1-binding-1-policy",
+              content: {
+                plugins: {
+                  "open-policy-agent": true,
+                  "pod-security-standards": true
+                }
+              },
+              project: {
+                id: "cluster-1-binding-1-policy-project",
+                name: "cluster-1-binding-1-policy-project"
+              }
             }
-          ],
-          bindings: [
-            {
-              id: "cluster-1-binding-1",
-              mode: "ALLOW_LIST",
-              namespaces: ["my-namespace-0","my-namespace-1"],
-              policy: {
-                id: "cluster-1-binding-1-policy",
-                content: {
+          },
+          {
+            id: "cluster-1-binding-2",
+            mode: "ALLOW_LIST",
+            namespaces: ["ns-2","ns-1"],
+            policy: {
+              id: "cluster-1-binding-2-policy",
+              content: {
                   plugins: {
-                    "open-policy-agent": true,
-                    "pod-security-standards": true
+                    'yaml-syntax': true,
+                    'open-policy-agent': true,
+                    'resource-links': true,
+                  },
+                  rules: {
+                    'yaml-syntax/no-bad-alias': "warn",
+                    'yaml-syntax/no-bad-directive': false,
+                    'open-policy-agent/no-last-image': "err",
+                    'open-policy-agent/cpu-limit': "err",
+                    'open-policy-agent/memory-limit': "err",
+                    'open-policy-agent/memory-request': "err",
                   }
-                },
-                projectId: "cluster-1-binding-1-policy-project"
-              }
-            },
-            {
-              id: "cluster-1-binding-2",
-              mode: "ALLOW_LIST",
-              namespaces: ["my-namespace-2","my-namespace-1"],
-              policy: {
-                id: "cluster-1-binding-2-policy",
-                content: {
-                    plugins: {
-                      'yaml-syntax': true,
-                      'open-policy-agent': true,
-                      'resource-links': true,
-                    },
-                    rules: {
-                      'yaml-syntax/no-bad-alias': "warn",
-                      'yaml-syntax/no-bad-directive': false,
-                      'open-policy-agent/no-last-image': "err",
-                      'open-policy-agent/cpu-limit': "err",
-                      'open-policy-agent/memory-limit': "err",
-                      'open-policy-agent/memory-request': "err",
-                    }
-                },
-                projectId: "cluster-1-binding-2-policy-project"
+              },
+              project: {
+                id: "cluster-1-binding-2-policy-project",
+                name: "cluster-1-binding-2-policy-project"
               }
             }
-          ]
-        }
+          }
+        ]
       }
     }
   }

--- a/tests/src/utils/response-mocks.ts
+++ b/tests/src/utils/response-mocks.ts
@@ -35,6 +35,10 @@ export const RESPONSE_MOCK: Record<string, any> = {
           {
             id: "ns-1",
             name: "my-namespace-1"
+          },
+          {
+            id: "ns-2",
+            name: "my-namespace-2"
           }
         ],
         bindings: [
@@ -44,12 +48,7 @@ export const RESPONSE_MOCK: Record<string, any> = {
             namespaces: ["ns-0","ns-1"],
             policy: {
               id: "cluster-1-binding-1-policy",
-              content: {
-                plugins: {
-                  "open-policy-agent": true,
-                  "pod-security-standards": true
-                }
-              },
+              content: "plugins:\n  open-policy-agent: true\n  pod-security-standards: true\n",
               project: {
                 id: "cluster-1-binding-1-policy-project",
                 name: "cluster-1-binding-1-policy-project"
@@ -62,21 +61,7 @@ export const RESPONSE_MOCK: Record<string, any> = {
             namespaces: ["ns-2","ns-1"],
             policy: {
               id: "cluster-1-binding-2-policy",
-              content: {
-                  plugins: {
-                    'yaml-syntax': true,
-                    'open-policy-agent': true,
-                    'resource-links': true,
-                  },
-                  rules: {
-                    'yaml-syntax/no-bad-alias': "warn",
-                    'yaml-syntax/no-bad-directive': false,
-                    'open-policy-agent/no-last-image': "err",
-                    'open-policy-agent/cpu-limit': "err",
-                    'open-policy-agent/memory-limit': "err",
-                    'open-policy-agent/memory-request': "err",
-                  }
-              },
+              content: "plugins:\n  pod-security-standards: true\n  yaml-syntax: false\n  resource-links: false\n",
               project: {
                 id: "cluster-1-binding-2-policy-project",
                 name: "cluster-1-binding-2-policy-project"


### PR DESCRIPTION
This PR fixes couple of issues and adjust to Cloud API.

## Changes

- Simplified namespaces sending logic (without diffing as it's not needed now).
- Adjusted queries to match Cloud API.

## Fixes

- Replaced how Policy and Binding CRDs are updated. Earlier it was by replace, but it required `resourceVersion` (which would need to be fetched from resource). Now, it is done by patching resource.
- Reworked PolicyUpdater cache logic - it is used to determine if resource should be created, updated or deleted. Since it's in-memory, it gets wiped out when pod is recreated. I added init logic to populate the cache with existing resources read from the cluster.

## Checklist

- [x] tested locally
- [x] added new dependencies
- [ ] updated the docs
- [ ] added a test
