### PR TITLE
Use Map instead of Set to store namespaces

### DIFF
--- a/admission-controller/synchronizer/src/utils/namespace-listener.ts
+++ b/admission-controller/synchronizer/src/utils/namespace-listener.ts
@@ -4,7 +4,7 @@ import {InformerWrapper} from './get-informer.js';
 
 export class NamespaceListener {
   private _isRunning = false;
-  private _namespaces = new Set<V1Namespace>();
+  private _namespaces = new Map<string, V1Namespace>();
 
   constructor(
     private readonly _namespaceInformer: InformerWrapper<V1Namespace>,
@@ -20,7 +20,7 @@ export class NamespaceListener {
   }
 
   get namespaces(): string[] {
-    return Array.from(this._namespaces).map(namespace => namespace.metadata!.name!);
+    return Array.from(this._namespaces.keys());
   }
 
   async start() {
@@ -36,12 +36,12 @@ export class NamespaceListener {
   private onNamespace(namespace: V1Namespace) {
     this._logger.debug({msg: 'Namespace created/updated', namespace});
 
-    this._namespaces.add(namespace);
+    this._namespaces.set(namespace.metadata!.name!, namespace);
   }
 
   private onNamespaceRemoval(namespace: V1Namespace) {
     this._logger.debug({msg: 'Namespace removed', namespace});
 
-    this._namespaces.delete(namespace);
+    this._namespaces.delete(namespace.metadata!.name!);
   }
 }


### PR DESCRIPTION
This PR fixes an issue with storing namespaces. Since Set was used, deletion did not work because object used as key was different for delete event (object reference). As a result when namespace was deleted from the cluster, it was not propagated by synchronizer and outdated list of namespaces was used.

I changed it to Map to have namespace names as key.

## Changes

- None.

## Fixes

- As above.

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
