### PR TITLE
fix: use build-in helm '--namespace' flag to define namespace

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -115,8 +115,8 @@ jobs:
           VERSION: ${{ env.VERSION }}
         run: |
           helm package ./helm --version ${VERSION}
-          helm template ./helm --version ${VERSION} > install-standalone.yaml
-          helm template ./helm --version ${VERSION} --set automationToken=SAMPLE_TOKEN > install-cloud.yaml
+          helm template ./helm --version ${VERSION} --namespace monokle > install-standalone.yaml
+          helm template ./helm --version ${VERSION} --namespace monokle --set automationToken=SAMPLE_TOKEN > install-cloud.yaml
           mv monokle-admission-controller-${VERSION}.tgz helm.tgz
 
       - name: Create release and upload artifacts

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -70,11 +70,16 @@ jobs:
       - name: Start Minikube
         run: minikube start --extra-config=apiserver.enable-admission-plugins=ValidatingAdmissionWebhook
 
-      - name: Deploy Admission Controller
-        run: ./scripts/deploy-${{ matrix.type }}.sh host.minikube.internal:5000 SAMPLE_TOKEN
+      - name: Deploy Admission Controller (Standalone)
+        if: matrix.type == 'standalone'
+        run: ./scripts/deploy-${{ matrix.type }}.sh monokle
+
+      - name: Deploy Admission Controller (Cloud)
+        if: matrix.type == 'cloud'
+        run: ./scripts/deploy-${{ matrix.type }}.sh host.minikube.internal:5000 SAMPLE_TOKEN monokle
 
       - name: Preview namespace state
-        run: kubectl -n monokle-admission-controller get all,CustomResourceDefinition,ValidatingWebhookConfiguration,secrets
+        run: kubectl -n monokle get all,CustomResourceDefinition,ValidatingWebhookConfiguration,secrets
 
       - name: Install Dependencies
         working-directory: ./tests/
@@ -132,7 +137,9 @@ jobs:
             --set image.init.overridePath=admission-webhook-init \
             --set image.server.pullPolicy=Never \
             --set image.server.overridePath=admission-webhook \
-            --set logLevel=debug
+            --set logLevel=debug \
+            --set createNamespace=true \
+            --namespace=mac-test
 
       - name: Preview namespace state
         run: kubectl -n mac-test get all,CustomResourceDefinition,ValidatingWebhookConfiguration,secrets
@@ -201,7 +208,9 @@ jobs:
             --set image.synchronizer.overridePath=admission-synchronizer \
             --set logLevel=debug \
             --set cloudApiUrl="host.minikube.internal:5000" \
-            --set automationToken=SAMPLE_TOKEN
+            --set automationToken=SAMPLE_TOKEN \
+            --set createNamespace=true \
+            --namespace=mac-test
 
       - name: Preview namespace state
         run: kubectl -n mac-test get all,CustomResourceDefinition,ValidatingWebhookConfiguration,secrets

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -140,6 +140,9 @@ jobs:
             --namespace=mac-test \
             --create-namespace
 
+      - name: List charts
+        run: helm list -A
+
       - name: Preview namespace state
         run: kubectl -n mac-test get all,CustomResourceDefinition,ValidatingWebhookConfiguration,secrets
 
@@ -150,6 +153,9 @@ jobs:
       - name: Test
         working-directory: ./tests/
         run: MONOKLE_NAMESPACE=mac-test npm run test standalone
+
+      - name: Helm uninstall
+        run: helm uninstall monokle-ac -n mac-test
 
   test-helm-cloud:
     name: Helm (Cloud)
@@ -210,6 +216,9 @@ jobs:
             --namespace=mac-test \
             --create-namespace
 
+      - name: List charts
+        run: helm list -A
+
       - name: Preview namespace state
         run: kubectl -n mac-test get all,CustomResourceDefinition,ValidatingWebhookConfiguration,secrets
 
@@ -220,3 +229,6 @@ jobs:
       - name: Test
         working-directory: ./tests/
         run: MONOKLE_NAMESPACE=mac-test npm run test cloud
+
+      - name: Helm uninstall
+        run: helm uninstall monokle-ac -n mac-test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -132,14 +132,13 @@ jobs:
           eval $(minikube -p minikube docker-env)
           helm package ./helm --version 0.0.0
           helm install monokle-ac monokle-admission-controller-0.0.0.tgz \
-            --set namespace=mac-test \
             --set image.init.pullPolicy=Never \
             --set image.init.overridePath=admission-webhook-init \
             --set image.server.pullPolicy=Never \
             --set image.server.overridePath=admission-webhook \
             --set logLevel=debug \
-            --set createNamespace=true \
-            --namespace=mac-test
+            --namespace=mac-test \
+            --create-namespace
 
       - name: Preview namespace state
         run: kubectl -n mac-test get all,CustomResourceDefinition,ValidatingWebhookConfiguration,secrets
@@ -199,7 +198,6 @@ jobs:
           eval $(minikube -p minikube docker-env)
           helm package ./helm --version 0.0.0
           helm install monokle-ac monokle-admission-controller-0.0.0.tgz \
-            --set namespace=mac-test \
             --set image.init.pullPolicy=Never \
             --set image.init.overridePath=admission-webhook-init \
             --set image.server.pullPolicy=Never \
@@ -209,8 +207,8 @@ jobs:
             --set logLevel=debug \
             --set cloudApiUrl="host.minikube.internal:5000" \
             --set automationToken=SAMPLE_TOKEN \
-            --set createNamespace=true \
-            --namespace=mac-test
+            --namespace=mac-test \
+            --create-namespace
 
       - name: Preview namespace state
         run: kubectl -n mac-test get all,CustomResourceDefinition,ValidatingWebhookConfiguration,secrets

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,14 +63,14 @@ helm install monokle-ac ./helm \
 --set image.server.overridePath=admission-webhook \
 --set image.synchronizer.pullPolicy=Never \
 --set image.synchronizer.overridePath=admission-synchronizer \
---set createNamespace=true \
---namespace monokle
+--namespace mac-test \
+--create-namespace
 ```
 
 Checking if it's ok:
 
 ```bash
-helm list
+helm list -A
 ```
 
 To uninstall:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ helm install monokle-ac ./helm \
 --set image.server.overridePath=admission-webhook \
 --set image.synchronizer.pullPolicy=Never \
 --set image.synchronizer.overridePath=admission-synchronizer \
---namespace mac-test \
+--namespace monokle \
 --create-namespace
 ```
 

--- a/README.md
+++ b/README.md
@@ -60,12 +60,12 @@ Learn more about each Core Plugin in the [Core Plugins Documentation](https://gi
 
 ## Installation
 
-Installing Monokle Admission Controller creates dedicated `monokle-admission-controller` namespace where all the namespaced resources are then deployed.
+Installing Monokle Admission Controller bunch of resources so it is recommended to install it to separate namespace. This can be done with `-n namespace` flag for Helm. For `install-*.yaml` scripts, it will be installed to **monokle** namespace which needs to be created before running install script.
 
 You can see all deployed resources with e.g. `kubectl`:
 
 ```bash
-kubectl -n monokle-admission-controller get all,CustomResourceDefinition,ValidatingWebhookConfiguration,secrets
+kubectl -n monokle get all,CustomResourceDefinition,ValidatingWebhookConfiguration,secrets
 ```
 
 ### With Cloud Sync
@@ -79,7 +79,7 @@ The only required configuration is an Automation Token which can be generated in
 Latest Monokle Admission controller can be installed directly from DockerHub OCI registry:
 
 ```bash
-helm install my-release oci://registry-1.docker.io/kubeshop/monokle-admission-controller --set automationToken=YOUR_AUTOMATION_TOKEN
+helm install my-release oci://registry-1.docker.io/kubeshop/monokle-admission-controller --set automationToken=YOUR_AUTOMATION_TOKEN -n monokle
 ```
 
 _You can read more about DockerHub OCI registry [here](https://docs.docker.com/docker-hub/oci-artifacts/)_.
@@ -87,8 +87,10 @@ _You can read more about DockerHub OCI registry [here](https://docs.docker.com/d
 Or from GitHub release:
 
 ```bash
-helm install my-release https://github.com/kubeshop/monokle-admission-controller/releases/download/v0.2.4/helm.tgz --set automationToken=YOUR_AUTOMATION_TOKEN
+helm install my-release https://github.com/kubeshop/monokle-admission-controller/releases/download/v0.2.4/helm.tgz --set automationToken=YOUR_AUTOMATION_TOKEN -n monokle
 ```
+
+> **Tip**: To create namespace automatically as part of `helm install`, use `--create-namespace` flag.
 
 > See [customization section](#customizing-helm-deployment) below on what can be customized with Helm variables.
 
@@ -97,6 +99,7 @@ helm install my-release https://github.com/kubeshop/monokle-admission-controller
 You can install Monokle Admission Controller using `kubectl` and dedicated cloud install manifest:
 
 ```bash
+kubectl create ns monokle && \
 kubectl apply -f https://github.com/kubeshop/monokle-admission-controller/releases/download/v0.2.4/install-cloud.yaml
 ```
 
@@ -113,7 +116,7 @@ kubectl patch secret monokle-synchronizer-token -p "{ \"data\": { \".token\": \"
 Latest Monokle Admission controller can be installed directly from DockerHub OCI registry:
 
 ```bash
-helm install my-release oci://registry-1.docker.io/kubeshop/monokle-admission-controller
+helm install my-release oci://registry-1.docker.io/kubeshop/monokle-admission-controller -n monokle
 ```
 
 _You can read more about DockerHub OCI registry [here](https://docs.docker.com/docker-hub/oci-artifacts/)_.
@@ -121,8 +124,10 @@ _You can read more about DockerHub OCI registry [here](https://docs.docker.com/d
 Or from GitHub release:
 
 ```bash
-helm install my-release https://github.com/kubeshop/monokle-admission-controller/releases/download/v0.2.4/helm.tgz
+helm install my-release https://github.com/kubeshop/monokle-admission-controller/releases/download/v0.2.4/helm.tgz -n monokle
 ```
+
+> **Tip**: To create namespace automatically as part of `helm install`, use `--create-namespace` flag.
 
 > See [customization section](#customizing-helm-deployment) below on what can be customized with Helm variables.
 
@@ -131,6 +136,7 @@ helm install my-release https://github.com/kubeshop/monokle-admission-controller
 You can install Monokle Admission Controller using `kubectl` and dedicated standalone install manifest:
 
 ```bash
+kubectl create ns monokle && \
 kubectl apply -f https://github.com/kubeshop/monokle-admission-controller/releases/download/v0.2.4/install-standalone.yaml
 ```
 
@@ -456,7 +462,6 @@ The `validationActions` supports `Warn` and `Deny` actions at this stage. `Warn`
 
 You can refer to [`helm/values.yaml`](./helm/values.yaml) file to see what can be change for Helm deployment. The most important values:
 
-* `namespace` - namespace to which Monokle Admission Controller will be deployed (defaults to `monokle-admission-controller`). We advise to always deploy it to dedicated namespace.
 * `ignoreNamespaces` - list of namespaces which should be ignored by admission controller (this option has priority over policy bindings and Cloud sync). By default Kubernetes system namespaces and Monokle Admission Controller namespace are ignored.
 * `replicas` - number of admission controller pod server replicas.
 * `automationToken` - Monokle Cloud automation token to enable syncing with the cloud.

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -3,7 +3,7 @@
 {{- end }}
 
 {{- define "monokle-admission-controller.namespace" -}}
-{{ default .Release.Namespace .Values.namespace }}
+{{ .Release.Namespace }}
 {{- end }}
 
 {{- define "monokle-admission-controller.chart" -}}

--- a/helm/templates/namespace.yaml
+++ b/helm/templates/namespace.yaml
@@ -1,6 +1,8 @@
+{{- if .Values.createNamespace }}
 apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ include "monokle-admission-controller.namespace" . }}
   labels:
     {{- include "monokle-admission-controller.labels" . | nindent 4 }}
+{{- end }}

--- a/helm/templates/namespace.yaml
+++ b/helm/templates/namespace.yaml
@@ -1,8 +1,0 @@
-{{- if .Values.createNamespace }}
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ include "monokle-admission-controller.namespace" . }}
-  labels:
-    {{- include "monokle-admission-controller.labels" . | nindent 4 }}
-{{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -23,8 +23,6 @@ image:
 
 replicas: 1
 
-createNamespace: false
-
 # Do not validate resources from below namespaces.
 ignoreNamespaces:
 #   - ns1

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -23,8 +23,7 @@ image:
 
 replicas: 1
 
-# Deploy Monokle Admission Controller resources to below namespace.
-namespace: monokle-admission-controller
+createNamespace: false
 
 # Do not validate resources from below namespaces.
 ignoreNamespaces:

--- a/scripts/deploy-cloud.sh
+++ b/scripts/deploy-cloud.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 basedir="$(dirname "$0")"
 cloudApiUrl="$1"
 automationToken="$2"
+namespace="$3"
 
 # Generate install.yaml
 #
@@ -19,7 +20,9 @@ helm template "${basedir}/../helm" \
 --set image.synchronizer.overridePath=admission-synchronizer \
 --set logLevel=debug \
 --set cloudApiUrl=$cloudApiUrl \
---set automationToken=$automationToken > "${basedir}/install.yaml"
+--set automationToken=$automationToken > "${basedir}/install.yaml" \
+--set createNamespace=true \
+--namespace "$namespace"
 
 # Run deployment through skaffold with locally build images
 skaffold run -f "${basedir}/skaffold.yaml"

--- a/scripts/deploy-cloud.sh
+++ b/scripts/deploy-cloud.sh
@@ -21,8 +21,10 @@ helm template "${basedir}/../helm" \
 --set logLevel=debug \
 --set cloudApiUrl=$cloudApiUrl \
 --set automationToken=$automationToken > "${basedir}/install.yaml" \
---set createNamespace=true \
 --namespace "$namespace"
+
+# Create namespace
+kubectl create ns "$namespace"
 
 # Run deployment through skaffold with locally build images
 skaffold run -f "${basedir}/skaffold.yaml"

--- a/scripts/deploy-standalone.sh
+++ b/scripts/deploy-standalone.sh
@@ -12,8 +12,10 @@ helm template "${basedir}/../helm" \
 --set image.init.overridePath=admission-webhook-init \
 --set image.server.overridePath=admission-webhook \
 --set logLevel=debug > "${basedir}/install.yaml" \
---set createNamespace=true \
 --namespace "$namespace"
+
+# Create namespace
+kubectl create ns "$namespace"
 
 # Run deployment through skaffold with locally build images
 skaffold run -f "${basedir}/skaffold.yaml"

--- a/scripts/deploy-standalone.sh
+++ b/scripts/deploy-standalone.sh
@@ -5,12 +5,15 @@
 set -euo pipefail
 
 basedir="$(dirname "$0")"
+namespace="$1"
 
 # Generate install.yaml
 helm template "${basedir}/../helm" \
 --set image.init.overridePath=admission-webhook-init \
 --set image.server.overridePath=admission-webhook \
---set logLevel=debug > "${basedir}/install.yaml"
+--set logLevel=debug > "${basedir}/install.yaml" \
+--set createNamespace=true \
+--namespace "$namespace"
 
 # Run deployment through skaffold with locally build images
 skaffold run -f "${basedir}/skaffold.yaml"

--- a/scripts/dev-cloud.sh
+++ b/scripts/dev-cloud.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 basedir="$(dirname "$0")"
 cloudApiUrl="$1"
 automationToken="$2"
+namespace="$3"
 
 # Generate install.yaml
 #
@@ -19,7 +20,9 @@ helm template "${basedir}/../helm" \
 --set image.synchronizer.overridePath=admission-synchronizer \
 --set logLevel=debug \
 --set cloudApiUrl=$cloudApiUrl \
---set automationToken=$automationToken > "${basedir}/install.yaml"
+--set automationToken=$automationToken > "${basedir}/install.yaml" \
+--set createNamespace=true \
+--namespace "$namespace"
 
 # Run development through skaffold with locally build images
 skaffold dev -f "${basedir}/skaffold.yaml"

--- a/scripts/dev-cloud.sh
+++ b/scripts/dev-cloud.sh
@@ -21,8 +21,10 @@ helm template "${basedir}/../helm" \
 --set logLevel=debug \
 --set cloudApiUrl=$cloudApiUrl \
 --set automationToken=$automationToken > "${basedir}/install.yaml" \
---set createNamespace=true \
 --namespace "$namespace"
+
+# Create namespace
+kubectl create ns "$namespace"
 
 # Run development through skaffold with locally build images
 skaffold dev -f "${basedir}/skaffold.yaml"

--- a/scripts/dev-standalone.sh
+++ b/scripts/dev-standalone.sh
@@ -12,8 +12,10 @@ helm template "${basedir}/../helm" \
 --set image.init.overridePath=admission-webhook-init \
 --set image.server.overridePath=admission-webhook \
 --set logLevel=debug > "${basedir}/install.yaml" \
---set createNamespace=true \
 --namespace "$namespace"
+
+# Create namespace
+kubectl create ns "$namespace"
 
 # Run development through skaffold with locally build images
 skaffold dev -f "${basedir}/skaffold.yaml"

--- a/scripts/dev-standalone.sh
+++ b/scripts/dev-standalone.sh
@@ -5,12 +5,15 @@
 set -euo pipefail
 
 basedir="$(dirname "$0")"
+namespace="$1"
 
 # Generate install.yaml
 helm template "${basedir}/../helm" \
 --set image.init.overridePath=admission-webhook-init \
 --set image.server.overridePath=admission-webhook \
---set logLevel=debug > "${basedir}/install.yaml"
+--set logLevel=debug > "${basedir}/install.yaml" \
+--set createNamespace=true \
+--namespace "$namespace"
 
 # Run development through skaffold with locally build images
 skaffold dev -f "${basedir}/skaffold.yaml"

--- a/tests/src/cloud.e2e.spec.ts
+++ b/tests/src/cloud.e2e.spec.ts
@@ -6,7 +6,7 @@ import { startMockServer } from './utils/server';
 import { EXPECTED_CRDS } from './utils/expected-crds';
 
 const VERBOSE = process.env.VERBOSE === 'true';
-const NAMESPACE = process.env.MONOKLE_NAMESPACE || 'monokle-admission-controller';
+const NAMESPACE = process.env.MONOKLE_NAMESPACE || 'monokle';
 
 const currentDir = __dirname;
 const mainDir = resolve(join(currentDir, '..', '..'));

--- a/tests/src/standalone.e2e.spec.ts
+++ b/tests/src/standalone.e2e.spec.ts
@@ -3,7 +3,7 @@ import { afterAll, afterEach, assert, beforeAll, describe, it } from 'vitest'
 import shell from 'shelljs';
 
 const VERBOSE = process.env.VERBOSE === 'true';
-const NAMESPACE = process.env.MONOKLE_NAMESPACE || 'monokle-admission-controller';
+const NAMESPACE = process.env.MONOKLE_NAMESPACE || 'monokle';
 
 const currentDir = __dirname;
 const mainDir = resolve(join(currentDir, '..', '..'));


### PR DESCRIPTION
This PR fixes #21.

After the changes, `-n` helm option is only used and full respected. This means that admission controller will be installed to namespace defined with `-n` flag, or default if flag not provided. For `install*.yaml` scripts target namespace is `monokle`.

I adjusted README to the above and highlighted there that it is recommended to install to separate namespace.

Related PR in the Cloud - https://github.com/kubeshop/monokle-saas/pull/2246.

## Changes

- As above.

## Fixes

- As above.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test
