### PR TITLE
Add client data to synchronizer instances

### DIFF
--- a/admission-controller/synchronizer/package-lock.json
+++ b/admission-controller/synchronizer/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@kubernetes/client-node": "^0.19.0",
-        "@monokle/synchronizer": "^0.10.2",
+        "@monokle/synchronizer": "^0.13.0",
         "lodash": "^4.17.21",
         "pino": "^8.16.1",
         "yaml": "^2.3.4"
@@ -59,9 +59,9 @@
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
     },
     "node_modules/@monokle/synchronizer": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@monokle/synchronizer/-/synchronizer-0.10.2.tgz",
-      "integrity": "sha512-l5xmz3RSq95RFPBBck/I0DzazDvi1PxICEu+8tZmCs/8a9dyWZ0+LuB4Js2xCpTFaSc30gbuCwIDM2FXKgWoPw==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@monokle/synchronizer/-/synchronizer-0.13.0.tgz",
+      "integrity": "sha512-rTfzoDC4A3mLkxYnpUeYHzLK2cIjugBarxJ3+Dyq8MgSbXcPmW5GaxbqTJRZX2KEPlj2ozJHRmXAsoxcOpwQVA==",
       "dependencies": {
         "@monokle/types": "*",
         "env-paths": "^2.2.1",

--- a/admission-controller/synchronizer/package-lock.json
+++ b/admission-controller/synchronizer/package-lock.json
@@ -16,6 +16,7 @@
         "yaml": "^2.3.4"
       },
       "devDependencies": {
+        "@types/git-url-parse": "^9.0.3",
         "@types/lodash": "^4.14.202",
         "@types/node": "^20.10.5",
         "typescript": "^5.3.3"
@@ -98,6 +99,12 @@
       "version": "0.12.4",
       "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.4.tgz",
       "integrity": "sha512-2in/lrHRNmDvHPgyormtEralhPcN3An1gLjJzj2Bw145VBxkQ75JEXW6CTdMAwShiHQcYsl2d10IjQSdJSJz4g=="
+    },
+    "node_modules/@types/git-url-parse": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@types/git-url-parse/-/git-url-parse-9.0.3.tgz",
+      "integrity": "sha512-Wrb8zeghhpKbYuqAOg203g+9YSNlrZWNZYvwxJuDF4dTmerijqpnGbI79yCuPtHSXHPEwv1pAFUB4zsSqn82Og==",
+      "dev": true
     },
     "node_modules/@types/js-yaml": {
       "version": "4.0.8",

--- a/admission-controller/synchronizer/package-lock.json
+++ b/admission-controller/synchronizer/package-lock.json
@@ -12,13 +12,13 @@
         "@kubernetes/client-node": "^0.19.0",
         "@monokle/synchronizer": "^0.13.0",
         "lodash": "^4.17.21",
-        "pino": "^8.16.1",
+        "pino": "^8.17.1",
         "yaml": "^2.3.4"
       },
       "devDependencies": {
-        "@types/lodash": "^4.14.200",
-        "@types/node": "^20.8.9",
-        "typescript": "^5.2.2"
+        "@types/lodash": "^4.14.202",
+        "@types/node": "^20.10.5",
+        "typescript": "^5.3.3"
       }
     },
     "node_modules/@kubernetes/client-node": {
@@ -105,15 +105,15 @@
       "integrity": "sha512-m6jnPk1VhlYRiLFm3f8X9Uep761f+CK8mHyS65LutH2OhmBF0BeMEjHgg05usH8PLZMWWc/BUR9RPmkvpWnyRA=="
     },
     "node_modules/@types/lodash": {
-      "version": "4.14.200",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.200.tgz",
-      "integrity": "sha512-YI/M/4HRImtNf3pJgbF+W6FrXovqj+T+/HpENLTooK9PnkacBsDpeP3IpHab40CClUfhNmdM2WTNP2sa2dni5Q==",
+      "version": "4.14.202",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.202.tgz",
+      "integrity": "sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==",
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.8.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.9.tgz",
-      "integrity": "sha512-UzykFsT3FhHb1h7yD4CA4YhBHq545JC0YnEz41xkipN88eKQtL6rSgocL5tbAP6Ola9Izm/Aw4Ora8He4x0BHg==",
+      "version": "20.10.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.5.tgz",
+      "integrity": "sha512-nNPsNE65wjMxEKI93yOP+NPGGBJz/PoN3kZsVLee0XMiJolxSekEVD8wRwBUBqkwc7UWop0edW50yrCQW4CyRw==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -787,9 +787,9 @@
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
     },
     "node_modules/pino": {
-      "version": "8.16.1",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-8.16.1.tgz",
-      "integrity": "sha512-3bKsVhBmgPjGV9pyn4fO/8RtoVDR8ssW1ev819FsRXlRNgW8gR/9Kx+gCK4UPWd4JjrRDLWpzd/pb1AyWm3MGA==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-8.17.1.tgz",
+      "integrity": "sha512-YoN7/NJgnsJ+fkADZqjhRt96iepWBndQHeClmSBH0sQWCb8zGD74t00SK4eOtKFi/f8TUmQnfmgglEhd2kI1RQ==",
       "dependencies": {
         "atomic-sleep": "^1.0.0",
         "fast-redact": "^3.1.1",
@@ -1110,9 +1110,9 @@
       "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
     },
     "node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/admission-controller/synchronizer/package.json
+++ b/admission-controller/synchronizer/package.json
@@ -17,6 +17,7 @@
     "yaml": "^2.3.4"
   },
   "devDependencies": {
+    "@types/git-url-parse": "^9.0.3",
     "@types/lodash": "^4.14.202",
     "@types/node": "^20.10.5",
     "typescript": "^5.3.3"

--- a/admission-controller/synchronizer/package.json
+++ b/admission-controller/synchronizer/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "dependencies": {
     "@kubernetes/client-node": "^0.19.0",
-    "@monokle/synchronizer": "^0.10.2",
+    "@monokle/synchronizer": "^0.13.0",
     "lodash": "^4.17.21",
     "pino": "^8.16.1",
     "yaml": "^2.3.4"

--- a/admission-controller/synchronizer/package.json
+++ b/admission-controller/synchronizer/package.json
@@ -13,12 +13,12 @@
     "@kubernetes/client-node": "^0.19.0",
     "@monokle/synchronizer": "^0.13.0",
     "lodash": "^4.17.21",
-    "pino": "^8.16.1",
+    "pino": "^8.17.1",
     "yaml": "^2.3.4"
   },
   "devDependencies": {
-    "@types/lodash": "^4.14.200",
-    "@types/node": "^20.8.9",
-    "typescript": "^5.2.2"
+    "@types/lodash": "^4.14.202",
+    "@types/node": "^20.10.5",
+    "typescript": "^5.3.3"
   }
 }

--- a/admission-controller/synchronizer/src/index.ts
+++ b/admission-controller/synchronizer/src/index.ts
@@ -28,7 +28,10 @@ const tokenPath = path.join('/run/secrets/token', '.token');
   kc.loadFromCluster();
 
   const apiFetcher = new Fetcher(
-    new ApiHandler(CLOUD_API_URL),
+    new ApiHandler({
+      name: 'Monokle AdmissionController',
+      version: CURRENT_VERSION,
+    }, CLOUD_API_URL),
   );
   const policyUpdater = new PolicyUpdater(kc, logger);
 

--- a/admission-controller/synchronizer/src/index.ts
+++ b/admission-controller/synchronizer/src/index.ts
@@ -16,7 +16,7 @@ const CLOUD_API_URL = process.env.MONOKLE_CLOUD_API_URL ?? '';
 
 const COMMUNICATION_INTERVAL_SEC = 15;
 
-const logger = pino({
+const logger = pino<string>({
   name: 'Monokle:Synchronizer',
   level: LOG_LEVEL,
 });
@@ -28,10 +28,10 @@ const tokenPath = path.join('/run/secrets/token', '.token');
   kc.loadFromCluster();
 
   const apiFetcher = new Fetcher(
-    new ApiHandler({
+    new ApiHandler(CLOUD_API_URL, {
       name: 'Monokle AdmissionController',
       version: CURRENT_VERSION,
-    }, CLOUD_API_URL),
+    }),
   );
   const policyUpdater = new PolicyUpdater(kc, logger);
 


### PR DESCRIPTION
This PR adds client data to synchronizer instances. Part of https://github.com/kubeshop/monokle-saas/issues/1904.

Requires https://github.com/kubeshop/monokle-core/pull/593.

## Changes

- As above.

## Fixes

- As above.

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
