### PR TITLE
fix: fix mapping of validation action for synchronized bindings

### DIFF
--- a/admission-controller/synchronizer/src/utils/policy-updater.ts
+++ b/admission-controller/synchronizer/src/utils/policy-updater.ts
@@ -216,7 +216,7 @@ export class PolicyUpdater {
 
     return {
       policyName: binding.policy.id,
-      validationActions: ['Warn'],
+      validationActions: [this.mapValidationAction(binding.action)],
       matchResources: {
         namespaceSelector: {
           matchExpressions: [{
@@ -238,5 +238,19 @@ export class PolicyUpdater {
     (binding2Copy as any).policy = { id: binding2.policy?.id };
 
     return _.isEqual(binding1Copy, binding2Copy);
+  }
+
+  protected mapValidationAction(action: string) {
+    const actionNormalized = action.toLowerCase().trim();
+
+    switch (actionNormalized) {
+      case 'warn':
+        return 'Warn';
+      case 'deny':
+        return 'Deny';
+      default:
+        this._logger.error({ msg: 'Unknown validation action', action });
+        return 'Warn';
+    }
   }
 }

--- a/admission-controller/synchronizer/src/utils/policy-updater.ts
+++ b/admission-controller/synchronizer/src/utils/policy-updater.ts
@@ -241,7 +241,7 @@ export class PolicyUpdater {
   }
 
   protected mapValidationAction(action: string) {
-    const actionNormalized = action.toLowerCase().trim();
+    const actionNormalized = (action || '').toLowerCase().trim();
 
     switch (actionNormalized) {
       case 'warn':
@@ -249,8 +249,8 @@ export class PolicyUpdater {
       case 'deny':
         return 'Deny';
       default:
-        this._logger.error({ msg: 'Unknown validation action', action });
-        return 'Warn';
+        this._logger.error({ msg: 'Unknown validation action.', action });
+        return action;
     }
   }
 }

--- a/admission-controller/synchronizer/src/utils/queries.ts
+++ b/admission-controller/synchronizer/src/utils/queries.ts
@@ -10,6 +10,7 @@ export type ClusterQueryResponseBindingPolicy = {
 export type ClusterQueryResponseBinding = {
   id: string
   mode: 'ALLOW_LIST' | 'BLOCK_LIST'
+  action: 'warn' | 'deny'
   namespaces: string[]
   policy: ClusterQueryResponseBindingPolicy
 };
@@ -53,6 +54,7 @@ export const getClusterQuery = `
       bindings {
         id
         mode
+        action
         namespaces
         policy {
           id

--- a/tests/src/cloud.e2e.spec.ts
+++ b/tests/src/cloud.e2e.spec.ts
@@ -81,6 +81,21 @@ describe(`Cloud (dir: ${mainDir})`, () => {
     assertResource(policy2, 'cluster-1-binding-2-policy');
   }, 45 * 1000);
 
+  it('correctly maps deny action', async () => {
+    mockServer = await startMockServer('actionDeny');
+
+    // Wait for getCluster query to run.
+    await waitForRequests(mockServer, 2);
+    // Wait for CRDs propagation.
+    await sleep(500);
+
+    const policy1 = await run('kubectl get monoklepolicy.monokle.io/cluster-1-binding-1-policy -o yaml');
+    const binding1 = await run('kubectl get monoklepolicybinding.monokle.io/cluster-1-binding-1-deny -o yaml');
+
+    assertResource(binding1, 'cluster-1-binding-1-deny');
+    assertResource(policy1, 'cluster-1-binding-1-policy');
+  }, 45 * 1000);
+
   // @TODO updates policy CRDs with new data
   // @TODO deletes policy CRDs
   // @TODO updates binding CRDs with new data

--- a/tests/src/utils/expected-crds.ts
+++ b/tests/src/utils/expected-crds.ts
@@ -19,6 +19,26 @@ export const EXPECTED_CRDS: Record<string, any> = {
       }
     }
   },
+  'cluster-1-binding-1-deny': {
+    apiVersion: 'monokle.io/v1alpha1',
+    kind: 'MonoklePolicyBinding',
+    metadata: {
+      name: 'cluster-1-binding-1-deny'
+    },
+    spec: {
+      policyName: 'cluster-1-binding-1-policy',
+      validationActions: ['Deny'],
+      matchResources: {
+        namespaceSelector: {
+          matchExpressions: [{
+            key: 'name',
+            operator: 'In',
+            values: ['my-namespace-0'],
+          }]
+        }
+      }
+    }
+  },
   'cluster-1-binding-2': {
     apiVersion: 'monokle.io/v1alpha1',
     kind: 'MonoklePolicyBinding',

--- a/tests/src/utils/response-mocks.ts
+++ b/tests/src/utils/response-mocks.ts
@@ -45,6 +45,7 @@ export const RESPONSE_MOCK: Record<string, any> = {
           {
             id: "cluster-1-binding-1",
             mode: "ALLOW_LIST",
+            action: "warn",
             namespaces: ["ns-0","ns-1"],
             policy: {
               id: "cluster-1-binding-1-policy",
@@ -58,6 +59,7 @@ export const RESPONSE_MOCK: Record<string, any> = {
           {
             id: "cluster-1-binding-2",
             mode: "ALLOW_LIST",
+            action: "warn",
             namespaces: ["ns-2","ns-1"],
             policy: {
               id: "cluster-1-binding-2-policy",
@@ -65,6 +67,37 @@ export const RESPONSE_MOCK: Record<string, any> = {
               project: {
                 id: "cluster-1-binding-2-policy-project",
                 name: "cluster-1-binding-2-policy-project"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  actionDeny: {
+    data: {
+      getCluster: {
+        id: "cluster-1",
+        name: "Cluster 1",
+        namespaceSync: true,
+        namespaces: [
+          {
+            id: "ns-0",
+            name: "my-namespace-0"
+          }
+        ],
+        bindings: [
+          {
+            id: "cluster-1-binding-1-deny",
+            mode: "ALLOW_LIST",
+            action: "deny",
+            namespaces: ["ns-0"],
+            policy: {
+              id: "cluster-1-binding-1-policy",
+              content: "plugins:\n  open-policy-agent: true\n  pod-security-standards: true\n",
+              project: {
+                id: "cluster-1-binding-1-policy-project",
+                name: "cluster-1-binding-1-policy-project"
               }
             }
           }

--- a/tests/src/utils/server.ts
+++ b/tests/src/utils/server.ts
@@ -4,7 +4,7 @@ import cors from 'cors';
 import _ from 'lodash';
 import {RESPONSE_MOCK} from './response-mocks.js';
 
-type ResponseMockName = 'empty' | 'emptySync' | 'dataAllow' | 'dataBlock';
+type ResponseMockName = 'empty' | 'emptySync' | 'dataAllow' | 'actionDeny';
 
 type MockServer = {
   server: Server;


### PR DESCRIPTION
This PR fixes mapping of validation action when synchronized from Cloud.

**Important**: This shouldn't be released as long as API changes from https://github.com/kubeshop/monokle-saas/pull/2324 are not in production, because then graphql query will break due to missing `action` property.

## Changes

- As above.

## Fixes

- As above.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
