### PR TITLE
fix: pin skaffold version and change installation method

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -57,7 +57,7 @@ jobs:
 
     steps:
       - name: Setup Skaffold
-        run: curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/latest/skaffold-linux-amd64 && sudo install skaffold /usr/local/bin/
+        run: curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/v2.9.0/skaffold-linux-amd64 && chmod +x skaffold && sudo mv skaffold /usr/local/bin
 
       - name: Setup Node.js
         uses: actions/setup-node@v2


### PR DESCRIPTION
This PR pins skaffold to previous version (`2.9.0`) because it started failing with latest one (`2.10.0`), for example: https://github.com/kubeshop/monokle-admission-controller/actions/runs/7569302057/job/20612383533#step:7:18.

## Changes

- As above.

## Fixes

- As above.

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
